### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+Reset.css linguist-language=HTML
+Style.css linguist-language=HTML

--- a/.github/ISSUE_TEMPLATE/achei-um-bug.md
+++ b/.github/ISSUE_TEMPLATE/achei-um-bug.md
@@ -24,7 +24,6 @@ o que você esperava que acontecesse
 se aplicável, prints do que aconteceu
 
 **Desktop (complete as informações, deixe em branco se for smartphone):**
- - OS: [e.g. iOS, Windows]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 


### PR DESCRIPTION
A detecção de linguagem do github é feita de acordo com o tamanho dos arquivos de cada linguagem, então fiz uma mudança no .gitattributes para considerar CSS como HTML